### PR TITLE
:sparkles: 修复carpet单人档退出时报错

### DIFF
--- a/src/main/java/club/mcams/carpet/mixin/carpet/CarpetServerMixin.java
+++ b/src/main/java/club/mcams/carpet/mixin/carpet/CarpetServerMixin.java
@@ -1,25 +1,46 @@
+/*
+ * This file is part of the Carpet AMS Addition project, licensed under the
+ * GNU Lesser General Public License v3.0
+ *
+ * Copyright (C) 2024 A Minecraft Server and contributors
+ *
+ * Carpet AMS Addition is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Carpet AMS Addition is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Carpet AMS Addition. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package club.mcams.carpet.mixin.carpet;
 
 import carpet.CarpetServer;
-import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import net.minecraft.server.MinecraftServer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(CarpetServer.class)
+@Mixin(value = CarpetServer.class,remap = false)
 public class CarpetServerMixin {
     //Just a fix for https://github.com/gnembon/fabric-carpet/issues/1908
 
     //#if MC>=11904
-    //$$ @WrapWithCondition(
+    //$$ @Inject(
     //$$         method = "onServerClosed(Lnet/minecraft/server/MinecraftServer;)V",
-    //$$         at = @At(
-    //$$                 value = "INVOKE",
-    //$$                 target = "Lcarpet/script/external/Vanilla;MinecraftServer_getScriptServer(Lnet/minecraft/server/MinecraftServer;)Lcarpet/script/CarpetScriptServer;"
-    //$$         )
+    //$$         at = @At("HEAD"),
+    //$$         cancellable = true
     //$$ )
-    //$$ private static boolean onlyCallifServerNotnull(MinecraftServer server) {
-    //$$     return server != null;
+    //$$ private static void onlyCallifServerNotnull(MinecraftServer server, CallbackInfo ci) {
+    //$$     if (server == null) {
+    //$$         ci.cancel();
+    //$$     }
     //$$ }
     //#endif
 }

--- a/src/main/java/club/mcams/carpet/mixin/carpet/CarpetServerMixin.java
+++ b/src/main/java/club/mcams/carpet/mixin/carpet/CarpetServerMixin.java
@@ -1,0 +1,25 @@
+package club.mcams.carpet.mixin.carpet;
+
+import carpet.CarpetServer;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(CarpetServer.class)
+public class CarpetServerMixin {
+    //Just a fix for https://github.com/gnembon/fabric-carpet/issues/1908
+
+    //#if MC>=11904
+    //$$ @WrapWithCondition(
+    //$$         method = "onServerClosed(Lnet/minecraft/server/MinecraftServer;)V",
+    //$$         at = @At(
+    //$$                 value = "INVOKE",
+    //$$                 target = "Lcarpet/script/external/Vanilla;MinecraftServer_getScriptServer(Lnet/minecraft/server/MinecraftServer;)Lcarpet/script/CarpetScriptServer;"
+    //$$         )
+    //$$ )
+    //$$ private static boolean onlyCallifServerNotnull(MinecraftServer server) {
+    //$$     return server != null;
+    //$$ }
+    //#endif
+}

--- a/src/main/resources/amscarpet.mixins.json
+++ b/src/main/resources/amscarpet.mixins.json
@@ -4,6 +4,7 @@
   "package": "club.mcams.carpet.mixin",
   "compatibilityLevel": "/*JAVA_VERSION*/",
   "mixins": [
+    "carpet.CarpetServerMixin",
     "carpet.HUDControllerMixin",
     "carpet.SettingsManagerMixin",
     "rule.amsUpdateSuppressionCrashFix.ChainRestrictedNeighborUpdater_SixWayEntryMixin",


### PR DESCRIPTION
通过在对应的调用中强制调用`server != null`的检查来避免崩溃。

这个修复算是拆东墙补西墙的修复，和本质修复（直接清理相关调用）不同。