### PR TITLE
修复ams-carpet会在其他不使用/carpet管理规则的地毯拓展下展示版本信息的bug & 更新issue模板

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,8 +57,8 @@ body:
   - type: input
     id: mod-version
     attributes:
-      label: TemplateMod version
-      description: The TemplateMod version(s) where this bug occurs in.
+      label: Carpet AMS Addition version
+      description: The Carpet AMS Addition version(s) where this bug occurs in.
       placeholder: 1.2.3
     validations:
       required: true

--- a/src/main/java/club/mcams/carpet/mixin/carpet/SettingsManagerMixin.java
+++ b/src/main/java/club/mcams/carpet/mixin/carpet/SettingsManagerMixin.java
@@ -20,6 +20,7 @@
 
 package club.mcams.carpet.mixin.carpet;
 
+import carpet.CarpetServer;
 import carpet.settings.SettingsManager;
 
 import club.mcams.carpet.AmsServer;
@@ -59,14 +60,16 @@ public abstract class SettingsManagerMixin {
         remap = false
     )
     private void printVersion(ServerCommandSource source, CallbackInfoReturnable<Integer> cir) {
-        Messenger.tell(
-            source,
-            Messenger.c(
-                String.format("g %s ", AmsServer.fancyName),
-                String.format("g %s: ", translator.tr("version").getString()),
-                String.format("g %s ", AmsServerMod.getVersion()),
-                String.format("g (%s: %d)", translator.tr("total_rules").getString(), AmsServer.ruleCount)
-            )
-        );
+        if ((Object)this == CarpetServer.settingsManager) {
+            Messenger.tell(
+                    source,
+                    Messenger.c(
+                            String.format("g %s ", AmsServer.fancyName),
+                            String.format("g %s: ", translator.tr("version").getString()),
+                            String.format("g %s ", AmsServerMod.getVersion()),
+                            String.format("g (%s: %d)", translator.tr("total_rules").getString(), AmsServer.ruleCount)
+                    )
+            );
+        }
     }
 }


### PR DESCRIPTION
## BUG

ams-carpet会把自己的版本信息打印在其他使用自定义命令管理规则的地毯下面
<img width="548" alt="屏幕截图 2025-01-30 004136" src="https://github.com/user-attachments/assets/e0754ea4-0fba-48d2-88d8-103eef71ee2f" />

## 原因

https://github.com/Minecraft-AMS/Carpet-AMS-Addition/blob/bd9fe509b9b91d29ee1b0ca6d5ed92b1ebbb1b96/src/main/java/club/mcams/carpet/mixin/carpet/SettingsManagerMixin.java#L61-L71

此mixin中并没有对`SettingsManager`对象是否由carpet创建检查, 从而导致版本信息会打印在其他自己创建`SettingsManager`的拓展中

## 修复

检查`SettingsManager`是否由carpet创建即可

使用此补丁后:
<img width="659" alt="屏幕截图 2025-01-30 005504" src="https://github.com/user-attachments/assets/cdf3e9f1-a317-4185-8f18-a0f78eeb7339" />

## 其他

问题模板的`TemplateMod`没改, 顺手给改了
